### PR TITLE
Refresh Tier2 connection using the latest configuration before retrying

### DIFF
--- a/DBSyncTool/MainForm.cs
+++ b/DBSyncTool/MainForm.cs
@@ -604,6 +604,8 @@ namespace DBSyncTool
             {
                 if (_orchestrator != null)
                 {
+                    // Save current configuration from UI to refresh Tier2 connection
+                    SaveConfigurationFromUI();
                     await _orchestrator.RetryFailedAsync();
                 }
             });

--- a/DBSyncTool/Services/CopyOrchestrator.cs
+++ b/DBSyncTool/Services/CopyOrchestrator.cs
@@ -10,7 +10,7 @@ namespace DBSyncTool.Services
     public class CopyOrchestrator
     {
         private readonly AppConfiguration _config;
-        private readonly Tier2DataService _tier2Service;
+        private Tier2DataService _tier2Service;
         private readonly AxDbDataService _axDbService;
         private readonly Action<string> _logger;
         private readonly TimestampManager _timestampManager;
@@ -338,6 +338,10 @@ namespace DBSyncTool.Services
             {
                 _logger("─────────────────────────────────────────────");
                 _logger("Starting Retry Failed...");
+
+                // Refresh Tier2 connection using the latest configuration before retrying
+                _logger("Refreshing Tier2 connection before retry");
+                _tier2Service = new Tier2DataService(_config.Tier2Connection, _logger);
 
                 var failedTables = _tables
                     .Where(t => t.Status == TableStatus.FetchError ||


### PR DESCRIPTION
The JIT SQL connection is time-limited (8 hours). If the connection expires, the pending tables will end up in error. Before restarting the transfer of tables in error, it is necessary to update the Tier2 connection. However, CopyOrchestrator works with an already cached Tier 2 connection.